### PR TITLE
refactor: move rn-permissions in demo app dep

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -131,8 +131,5 @@
         "jsSrcsDir": "src"
       }
     ]
-  },
-  "dependencies": {
-    "react-native-permissions": "^3.6.1"
   }
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -18,7 +18,8 @@
     "postinstall-postinstall": "^2.1.0",
     "react": "18.1.0",
     "react-native": "0.70.5",
-    "react-native-battery-optimization-check": "^1.0.8"
+    "react-native-battery-optimization-check": "^1.0.8",
+    "react-native-permissions": "^3.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
`react-native-permissions` is not a core package dependencies.
It is a demo package one.