### PR TITLE
chore: remove deprecated iOS Property List Key NSLocationAlwaysUsageDescription

### DIFF
--- a/packages/demo/ios/DriveKitRNDemoApp/Info.plist
+++ b/packages/demo/ios/DriveKitRNDemoApp/Info.plist
@@ -47,8 +47,6 @@
 	<string>The application needs to use bluetooth in order to retrieve beacon battery level</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>To enable automatic trip detection and driving analysis without having to manipulate your phone, select the option "Always allow". Good road...</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>The application needs to know your location to analyze your trips, to provide driving scores and to enable use the automatic start mode.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>To automatically detect and analyze your trips, the application needs access to your position at all times.</string>
 	<key>NSMotionUsageDescription</key>

--- a/packages/trip-analysis/README.md
+++ b/packages/trip-analysis/README.md
@@ -118,7 +118,6 @@ For location permission, please use [requestIOSLocationPermission()](https://git
 
 When the application requests permission for background locations or motion activities, a message will be shown to the user. You must configure this message by changing the value for the following keys in `Info.plist`
 
-- `NSLocationAlwaysUsageDescription`
 - `NSLocationWhenInUseUsageDescription`
 - `NSLocationAlwaysAndWhenInUseUsageDescription`
 - `NSMotionUsageDescription`


### PR DESCRIPTION
chore: remove deprecated iOS Property List Key NSLocationAlwaysUsageDescription