### PR TITLE
feat: expose set beacon required method

### DIFF
--- a/packages/demo/src/components/Sections/TripAnalysisSection.tsx
+++ b/packages/demo/src/components/Sections/TripAnalysisSection.tsx
@@ -224,6 +224,19 @@ const TripAnalysisSection: FunctionComponent<{}> = () => {
       />
       <Spacer factor={1} />
       <Button
+        title="Set Beacon required"
+        onPress={async () => {
+          await DriveKitTripAnalysis.setBeaconRequired(true);
+        }}
+      />
+      <Button
+        title="Set Beacon not required"
+        onPress={async () => {
+          await DriveKitTripAnalysis.setBeaconRequired(false);
+        }}
+      />
+      <Spacer factor={1} />
+      <Button
         title={'Enable CrashDetection'}
         onPress={() => {
           DriveKitTripAnalysis.activateCrashDetection(true);

--- a/packages/trip-analysis/README.md
+++ b/packages/trip-analysis/README.md
@@ -237,6 +237,7 @@ Follow these steps :
 | [updateTripMetadata(key: string, value: string)](#updateTripMetadata)               | `Promise<void>`                          | ✅  |   ✅    |
 | [setVehicle(vehicle: Partial<TripVehicle> \| null)](#setVehicle)                    | `Promise<void>`                          | ✅  |   ✅    |
 | [setBeacons(beacons: Array\<BeaconData\>)](#setBeacons)                             | `Promise<void>`                          | ✅  |   ✅    |
+| [setBeaconRequired(required: Boolean)](#setBeaconRequired)                          | `Promise<void>`                          | ✅  |   ✅    |
 | [getCurrentTripInfo()](#getCurrentTripInfo)                                         | `Promise<CurrentTripInfo \| null>`       | ✅  |   ✅    |
 | [getLastTripLocation()](#getLastTripLocation)                                       | `Promise<LastTripLocation \| null>`      | ✅  |   ✅    |
 | [getLastVehicleTripLocation()](#getLastVehicleTripLocation)                         | `Promise<LastTripLocation \| null>`      | ✅  |   ✅    |
@@ -523,6 +524,14 @@ await DriveKitTripAnalysis.setBeacons([{
 
 If you want to ignore major and minor values for trip detection, set them to -1.
 If you want to remove beacons from SDK configuration, call the method with an empty array.
+
+### setBeaconRequired
+```typescript
+setBeaconRequired(required: Boolean): Promise<void>
+```
+To avoid the recording of unwanted trips (trips performed outside the vehicle where the beacon is placed), it is possible to automatically cancel the trip if the beacon is not "seen" several times during the trip. Generally, a trip will be cancelled in less than 6 minutes if the beacon is not in the vehicle.
+
+By default, this setting is disabled but you can enable/disable it by calling the `setBeaconRequired` method
 
 ### getCurrentTripInfo
 

--- a/packages/trip-analysis/android/src/legacy/DriveKitTripAnalysisSpec.kt
+++ b/packages/trip-analysis/android/src/legacy/DriveKitTripAnalysisSpec.kt
@@ -27,8 +27,9 @@ abstract class DriveKitTripAnalysisSpec internal constructor(context: ReactAppli
 
   abstract fun setVehicle(vehicle: ReadableMap, promise: Promise)
 
-
   abstract fun setBeacons(beacons: ReadableArray, promise: Promise)
+
+  abstract fun setBeaconRequired(required: Boolean, promise: Promise)
 
   abstract fun getTripMetadata(promise: Promise)
 

--- a/packages/trip-analysis/android/src/main/java/com/reactnativedrivekittripanalysis/DriveKitTripAnalysisModule.kt
+++ b/packages/trip-analysis/android/src/main/java/com/reactnativedrivekittripanalysis/DriveKitTripAnalysisModule.kt
@@ -147,6 +147,12 @@ class DriveKitTripAnalysisModule internal constructor(context: ReactApplicationC
   }
 
   @ReactMethod
+  override fun setBeaconRequired(required: Boolean, promise: Promise) {
+    DriveKitTripAnalysis.setBeaconRequired(required)
+    promise.resolve(null)
+  }
+
+  @ReactMethod
   override fun getCurrentTripInfo(promise: Promise) {
     promise.resolve(DKTripInfoMapper.mapDKTripInfoToReadableMap(DriveKitTripAnalysis.getCurrentTripInfo()))
   }

--- a/packages/trip-analysis/ios/RNDriveKitTripAnalysis-Swift.h
+++ b/packages/trip-analysis/ios/RNDriveKitTripAnalysis-Swift.h
@@ -23,6 +23,7 @@
 - (void)updateTripMetadataWithKey:(NSString * _Nonnull)key value:(NSString * _Nullable)value;
 - (void)setVehicleWithVehicle:(NSDictionary * _Nullable)vehicle;
 - (void)setBeaconsWithBeacons:(NSArray * _Nullable)beacons;
+- (void)setBeaconRequiredWithRequired:(BOOL)required;
 - (NSDictionary * _Nullable)getCurrentTripInfoWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve rejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 - (NSDictionary * _Nullable)getLastTripLocationWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve rejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 - (NSDictionary * _Nullable)getLastVehicleTripLocationWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve rejecter:(RCTPromiseRejectBlock _Nonnull)reject;

--- a/packages/trip-analysis/ios/RNDriveKitTripAnalysis.mm
+++ b/packages/trip-analysis/ios/RNDriveKitTripAnalysis.mm
@@ -184,6 +184,12 @@ RCT_EXPORT_METHOD(setBeacons:(NSArray *)beacons resolve:(RCTPromiseResolveBlock)
     resolve(nil);
 }
 
+RCT_EXPORT_METHOD(setBeaconRequired:(BOOL)required resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+    [self setBeaconRequired:required];
+    resolve(nil);
+}
+
 RCT_EXPORT_METHOD(getCurrentTripInfo:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
     [self getCurrentTripInfo:resolve rejecter:reject];
@@ -278,6 +284,10 @@ RCT_EXPORT_METHOD(revokeTripSharingLink:(RCTPromiseResolveBlock)resolve reject:(
 
 -(void)setBeacons:(NSArray *)beacons {
     [RNDriveKitTripAnalysisWrapper.shared setBeaconsWithBeacons:beacons];
+}
+
+-(void)setBeaconRequired:(BOOL)required {
+    [RNDriveKitTripAnalysisWrapper.shared setBeaconRequiredWithRequired:required];
 }
 
 -(void)getCurrentTripInfo:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {

--- a/packages/trip-analysis/ios/RNDriveKitTripAnalysisWrapper.swift
+++ b/packages/trip-analysis/ios/RNDriveKitTripAnalysisWrapper.swift
@@ -82,6 +82,10 @@ public class RNDriveKitTripAnalysisWrapper: NSObject {
         let beaconObjects = beacons.map { beacon in mapNSDictionaryToBeacon(dictionary: beacon) }
         DriveKitTripAnalysis.shared.setBeacons(beacons: beaconObjects)
     }
+
+    @objc internal func setBeaconRequired(required: Bool) -> Void {
+        DriveKitTripAnalysis.shared.setBeaconRequired(required: required)
+    }
     
     @objc internal func getCurrentTripInfo(resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       if let tripInfo = DriveKitTripAnalysis.shared.getCurrentTripInfo() {

--- a/packages/trip-analysis/src/NativeDriveKitTripAnalysis.ts
+++ b/packages/trip-analysis/src/NativeDriveKitTripAnalysis.ts
@@ -285,6 +285,7 @@ export interface Spec extends TurboModule {
   updateTripMetadata(key: string, value: string): Promise<void>;
   setVehicle(vehicle: TripVehicle): Promise<void>;
   setBeacons(beacons: Array<BeaconData>): Promise<void>;
+  setBeaconRequired(required: boolean): Promise<void>;
   getCurrentTripInfo(): Promise<CurrentTripInfo>;
   getLastTripLocation(): Promise<LastTripLocation>;
   getLastVehicleTripLocation(): Promise<LastTripLocation>;

--- a/packages/trip-analysis/src/api.tsx
+++ b/packages/trip-analysis/src/api.tsx
@@ -79,6 +79,10 @@ export function setBeacons(beacons: BeaconData[]): Promise<void> {
   return DriveKitTripAnalysis.setBeacons(beacons);
 }
 
+export function setBeaconRequired(required: Boolean): Promise<void> {
+  return DriveKitTripAnalysis.setBeaconRequired(required);
+}
+
 export function addEventListener(
   eventName: string,
   callback: Function


### PR DESCRIPTION
# Test plan
## Android
Press "set beacon required" 
check DriveKitPreferences file in DeviceManager (data/data/com.drivequant.drivekit.flutter.example/shared_prefs)
<img width="865" height="358" alt="image" src="https://github.com/user-attachments/assets/92926b6f-ad7e-4b79-bac2-e20312962056" />

Press "set beacon not required"
<img width="837" height="352" alt="image" src="https://github.com/user-attachments/assets/aabb314d-db56-4bd9-a55f-7e3ee2d3d29c" />


## iOS
Press "set beacon required" 

<img width="360" height="57" alt="image" src="https://github.com/user-attachments/assets/df1d5fc2-f10a-4e73-a5ce-054879aae993" />

check UserDefaults by downloading App container : Window > Device and simulator > Select "DriveKit Flutter Demo" > "..." button > Download container > Rename xcappdata file as zip > AppData > Library > Preferences

Press "set beacon not required"

<img width="346" height="68" alt="image" src="https://github.com/user-attachments/assets/c56d7368-f652-4440-ab5c-a7f159d05b11" />